### PR TITLE
Fixes flaky placement tests on windows

### DIFF
--- a/tests/integration/suite/actors/reminders/scheduler/remove.go
+++ b/tests/integration/suite/actors/reminders/scheduler/remove.go
@@ -140,7 +140,7 @@ func (r *remove) Run(t *testing.T, ctx context.Context) {
 		keys, rerr := etcdClient.ListAllKeys(ctx, "dapr/jobs")
 		require.NoError(c, rerr)
 		assert.Len(c, keys, 1)
-	}, time.Second*10, 10*time.Millisecond)
+	}, time.Second*20, 10*time.Millisecond)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, int64(1), r.triggered.Load())

--- a/tests/integration/suite/daprd/jobs/remove.go
+++ b/tests/integration/suite/daprd/jobs/remove.go
@@ -111,7 +111,7 @@ func (r *remove) Run(t *testing.T, ctx context.Context) {
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		keys, rerr := etcdClient.ListAllKeys(ctx, "dapr/jobs")
-		require.NoError(c, rerr)
+		assert.NoError(c, rerr)
 		assert.Len(c, keys, 1)
 	}, time.Second*10, 10*time.Millisecond)
 

--- a/tests/integration/suite/placement/apilevel/no_max.go
+++ b/tests/integration/suite/placement/apilevel/no_max.go
@@ -55,7 +55,7 @@ func (n *noMax) Run(t *testing.T, ctx context.Context) {
 
 	httpClient := client.HTTP(t)
 
-	n.place.WaitUntilRunning(t, ctx)
+	n.place.WaitUntilLeader(t, ctx)
 
 	currentVersion := atomic.Uint32{}
 	lastVersionUpdate := atomic.Int64{}

--- a/tests/integration/suite/placement/apilevel/with_max.go
+++ b/tests/integration/suite/placement/apilevel/with_max.go
@@ -55,7 +55,7 @@ func (n *withMax) Run(t *testing.T, ctx context.Context) {
 
 	httpClient := client.HTTP(t)
 
-	n.place.WaitUntilRunning(t, ctx)
+	n.place.WaitUntilLeader(t, ctx)
 
 	// Collect messages
 	currentVersion := atomic.Uint32{}

--- a/tests/integration/suite/placement/apilevel/with_min.go
+++ b/tests/integration/suite/placement/apilevel/with_min.go
@@ -58,7 +58,7 @@ func (n *withMin) Run(t *testing.T, ctx context.Context) {
 
 	httpClient := client.HTTP(t)
 
-	n.place.WaitUntilRunning(t, ctx)
+	n.place.WaitUntilLeader(t, ctx)
 
 	currentVersion := atomic.Uint32{}
 	lastVersionUpdate := atomic.Int64{}

--- a/tests/integration/suite/placement/authz/nomtls.go
+++ b/tests/integration/suite/placement/authz/nomtls.go
@@ -45,7 +45,7 @@ func (n *nomtls) Setup(t *testing.T) []framework.Option {
 }
 
 func (n *nomtls) Run(t *testing.T, ctx context.Context) {
-	n.place.WaitUntilRunning(t, ctx)
+	n.place.WaitUntilLeader(t, ctx)
 
 	host := n.place.Address()
 	//nolint:staticcheck

--- a/tests/integration/suite/placement/dissemination/notls.go
+++ b/tests/integration/suite/placement/dissemination/notls.go
@@ -44,7 +44,7 @@ func (n *notls) Setup(t *testing.T) []framework.Option {
 }
 
 func (n *notls) Run(t *testing.T, ctx context.Context) {
-	n.place.WaitUntilRunning(t, ctx)
+	n.place.WaitUntilLeader(t, ctx)
 
 	t.Run("actors in different namespaces are disseminated properly", func(t *testing.T) {
 		host1 := &v1pb.Host{

--- a/tests/integration/suite/placement/vnodes/vnodes.go
+++ b/tests/integration/suite/placement/vnodes/vnodes.go
@@ -46,7 +46,7 @@ func (v *vnodes) Setup(t *testing.T) []framework.Option {
 }
 
 func (v *vnodes) Run(t *testing.T, ctx context.Context) {
-	v.place.WaitUntilRunning(t, ctx)
+	v.place.WaitUntilLeader(t, ctx)
 
 	t.Run("register host without vnodes metadata (simulating daprd <1.13)", func(t *testing.T) {
 		// Register the host, with API level 10 (pre v1.13)

--- a/tests/integration/suite/scheduler/api/remove.go
+++ b/tests/integration/suite/scheduler/api/remove.go
@@ -107,7 +107,7 @@ func (r *remove) Run(t *testing.T, ctx context.Context) {
 		keys, rerr := etcdClient.ListAllKeys(ctx, "dapr/jobs")
 		require.NoError(c, rerr)
 		assert.Len(c, keys, 1)
-	}, time.Second*10, 10*time.Millisecond)
+	}, time.Second*30, 10*time.Millisecond)
 
 	job, err := watch.Recv()
 	require.NoError(t, err)
@@ -123,7 +123,7 @@ func (r *remove) Run(t *testing.T, ctx context.Context) {
 		keys, rerr := etcdClient.ListAllKeys(ctx, "dapr/jobs")
 		require.NoError(c, rerr)
 		assert.Len(c, keys, 1)
-	}, time.Second*10, 10*time.Millisecond)
+	}, time.Second*30, 10*time.Millisecond)
 
 	_, err = client.DeleteJob(ctx, &schedulerv1.DeleteJobRequest{
 		Name: "test",
@@ -135,7 +135,7 @@ func (r *remove) Run(t *testing.T, ctx context.Context) {
 			},
 		},
 	})
-	require.NoError(t, err)
+	require.NoError(t, err, "Unexpected err message:"+err.Error())
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		keys, rerr := etcdClient.ListAllKeys(ctx, "dapr/jobs")

--- a/tests/integration/suite/scheduler/api/remove.go
+++ b/tests/integration/suite/scheduler/api/remove.go
@@ -105,7 +105,7 @@ func (r *remove) Run(t *testing.T, ctx context.Context) {
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		keys, rerr := etcdClient.ListAllKeys(ctx, "dapr/jobs")
-		require.NoError(c, rerr)
+		assert.NoError(c, rerr)
 		assert.Len(c, keys, 1)
 	}, time.Second*30, 10*time.Millisecond)
 
@@ -121,7 +121,7 @@ func (r *remove) Run(t *testing.T, ctx context.Context) {
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		keys, rerr := etcdClient.ListAllKeys(ctx, "dapr/jobs")
-		require.NoError(c, rerr)
+		assert.NoError(c, rerr)
 		assert.Len(c, keys, 1)
 	}, time.Second*30, 10*time.Millisecond)
 


### PR DESCRIPTION
Adds a `WaitUntilLeader` method for the placement service in the integration testing framework